### PR TITLE
Include user info on questions, answers, comments and projects

### DIFF
--- a/pulse/serializers.py
+++ b/pulse/serializers.py
@@ -5,33 +5,44 @@ from .models import Answers, Questions, Projects, Users, Comments, Tags
 # conversion of incoming data, as well as serializing outgoing data to be
 # returned in responses.
 
-        
-class TagSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Tags
-        fields = '__all__'
-
-class AnswerSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Answers
-        fields = '__all__'  # or specify the fields you want
-        
-class ProjectSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Projects
-        fields = '__all__'
-
-class QuestionSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Questions
-        fields = '__all__'
-
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = Users
         fields = '__all__'
         
+class AnswerSerializer(serializers.ModelSerializer):
+    # This allows us to get the user info of the answerer as a dictionary, based on the expert_id (for GET requests)
+    expert_info = UserSerializer(source='expert', read_only=True)
+    
+    class Meta:
+        model = Answers
+        fields = '__all__'  # or specify the fields you want
+        
 class CommentSerializer(serializers.ModelSerializer):
+    # This allows us to get the user info of the commenter as a dictionary, based on the expert_id (for GET requests)
+    expert_info = UserSerializer(source='expert', read_only=True)
+    
     class Meta:
         model = Comments
         fields = '__all__' 
+        
+class ProjectSerializer(serializers.ModelSerializer):
+   # This allows us to get the user info of the owner as a dictionary, based on the owner_id (for GET requests)
+    owner_info = UserSerializer(source='owner', read_only=True)
+    
+    class Meta:
+        model = Projects
+        fields = '__all__'
+
+class QuestionSerializer(serializers.ModelSerializer):
+    # This allows us to get the user info of the asker as a dictionary, based on the asker_id (for GET requests)
+    asker_info = UserSerializer(source='asker', read_only=True)
+    
+    class Meta:
+        model = Questions
+        fields = '__all__'
+        
+class TagSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Tags
+        fields = '__all__'

--- a/pulse/views/answer_views.py
+++ b/pulse/views/answer_views.py
@@ -17,10 +17,9 @@ def createAnswer(request: HttpRequest) -> JsonResponse:
     serializer = AnswerSerializer(data=request.data)  # Use request.data for DRF (djang-rest-framework) compatibility
     if serializer.is_valid():
         answer = serializer.save()  # Save the new answer
-        return JsonResponse(
-            {"answer_id": answer.answer_id,
-             "response": answer.response}, status=status.HTTP_201_CREATED
-        )
+        serialized_answer = AnswerSerializer(answer)  # Serialize the saved answer
+        return JsonResponse(serialized_answer.data, status=status.HTTP_201_CREATED)  # Return the serialized data
+
     return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 @api_view(["GET"])

--- a/pulse/views/comment_views.py
+++ b/pulse/views/comment_views.py
@@ -17,11 +17,9 @@ def createComment(request: HttpRequest) -> JsonResponse:
     serializer = CommentSerializer(data=request.data)  # Use request.data for DRF (djang-rest-framework) compatibility
     if serializer.is_valid():
         comment = serializer.save()  # Save the new comment
-        return JsonResponse(
-            {"comment_id": comment.comment_id,
-             "answer_id": comment.answer_id,
-             "response": comment.response}, status=status.HTTP_201_CREATED
-        )
+        serialized_comment = CommentSerializer(comment)  # Serialize the saved comment
+        return JsonResponse(serialized_comment.data, status=status.HTTP_201_CREATED)  # Return the serialized data
+
     return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 @api_view(["GET"])


### PR DESCRIPTION
## What does this PR do?
Adjusted backend serializers to include new fields that includes the associated user object as part of GET requests. This way user information can be accessed without having to do multiple API calls. Also needed to update the response when calling create for answers and comments, as before it was only returning the ID, but we need to entire object in order to update the frontend in real time with the newly created objects.

## PR Dependencies
N/A

## Type of change

- [ ] Fix: Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor: Any code refactoring
- [ ] Chore: technical debt, workflow improvements
- [x] Feature: New feature (non-breaking change which adds functionality)
- [ ] Documentation: This change requires a documentation update
- [ ] Release: New release to production (e.g. `v1.0.1`)

## Tests Performed
Tested locally with Supabase

## Screenshots

## Additional Comments
